### PR TITLE
Update bus elem state if polling fails

### DIFF
--- a/components/RaftI2C/BusI2C/DevicePollingMgr.cpp
+++ b/components/RaftI2C/BusI2C/DevicePollingMgr.cpp
@@ -106,6 +106,8 @@ void DevicePollingMgr::taskService(uint64_t timeNowUs)
 
             if (rslt != RAFT_OK)
             {
+                bool isOnline = true;
+                _busStatusMgr.updateBusElemState(address, false, isOnline);
                 allResultsOkAndComplete = false;
                 break;
             }


### PR DESCRIPTION
Register a failed poll as an elem not responding event so that it can be properly handled